### PR TITLE
fix: restore trip detail endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,3 +123,29 @@ lodging
 ```text
 airplane, bike, bus, car, roadtrip, cruise, ferry, motorcycle, train, walk
 ```
+
+## Pull Request Conventions
+
+- Do not prefix PR titles with `[codex]`.
+- Do not add `codex` labels, tags, or title markers.
+- Use a conventional PR title prefix that matches the change type:
+  - `fix:` for bug fixes
+  - `feat:` for user-facing features
+  - `chore:` for maintenance, release, dependency, or tooling work
+  - `test:` for test-only changes
+  - `refactor:` for behavior-preserving code restructuring
+  - `docs:` for documentation-only changes
+- Add the matching GitHub label when opening or updating a PR:
+  - `bug` for bug fixes
+  - `feature` for user-facing features
+  - `improvement` for behavior or UX improvements
+  - `chore` for maintenance, release, dependency, or tooling work
+  - `dependencies`, `github_actions`, `swift_package_manager`, or `performance` when those labels more specifically describe the work
+- Include the issue identifier when available:
+  - `fix(TRI-2234): correct ends in day count`
+  - `feat(TRI-2201): add route preference picker`
+  - `chore: update release tags`
+- Open PRs as ready for review unless explicitly asked to open a draft PR.
+- Every PR body must include `Summary`, `Implementation Details`, and `Validation` sections, plus the issue/ticket reference when available.
+- The `Implementation Details` section must explain the material code changes at file and symbol level: list newly created files, types, or components, and describe the functions, models, views, or existing files that were changed and what each change accomplishes.
+- Keep the `Implementation Details` section synchronized with the final diff before opening or updating the PR.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tripsyapp/cli
 
-go 1.26.3
+go 1.26.5
 
 require github.com/modelcontextprotocol/go-sdk v1.5.0
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1140,7 +1140,7 @@ func (a *app) trips(ctx context.Context, args []string) error {
 		if err != nil {
 			return err
 		}
-		resp, err := a.client.Request(ctx, "GET", "/v2/trips/"+apiPathSegment(id)+"/", nil, nil)
+		resp, err := a.client.Request(ctx, "GET", "/v1/trips/"+apiPathSegment(id), tripDataQuery(nil), nil)
 		if err != nil {
 			return err
 		}
@@ -2346,7 +2346,7 @@ func commandCatalog() []commandSpec {
 				"tripsy trips create --name Italy --starts-at 2026-06-01 --ends-at 2026-06-15 --timezone Europe/Rome --cover-image-url 'https://images.unsplash.com/photo-1529260830199-42c24126f198?ixlib=rb-4.1.0'",
 				"tripsy trips update 42 --description 'Summer vacation'",
 			},
-			Gotchas: []string{"Use a real direct images.unsplash.com/photo-<numeric timestamp>-<asset hash> URL copied from an image result for cover_image_url; do not use an unsplash.com/photos page URL or short IDs such as photo-nWdsya5_Yms.", "Trip and itinerary read commands use the lean v2 API and combine paginated results."},
+			Gotchas: []string{"Use a real direct images.unsplash.com/photo-<numeric timestamp>-<asset hash> URL copied from an image result for cover_image_url; do not use an unsplash.com/photos page URL or short IDs such as photo-nWdsya5_Yms.", "Trip lists and itinerary subresource reads use the lean v2 API and combine paginated results; individual trip detail reads use v1."},
 		},
 		resourceCommandSpec("hostings", "hosting", "Hotel and lodging plans", "tripsy hostings create --trip 42 --name 'Hotel Eden' --starts-at 2026-06-01T14:00:00Z"),
 		resourceCommandSpec("activities", "activity", "Scheduled or unscheduled trip activities", "tripsy activities create --trip 42 --name 'Colosseum Tour' --activity-type tour"),

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -143,7 +143,7 @@ func TestFormatFullObjectShowsDocumentedAndExtraFields(t *testing.T) {
 	}
 }
 
-func TestTripsCommandsUseV2ForReadsAndV1ForWrites(t *testing.T) {
+func TestTripsCommandsUseV2ForListsAndV1ForDetailsAndWrites(t *testing.T) {
 	for _, tt := range []struct {
 		name          string
 		args          []string
@@ -152,7 +152,7 @@ func TestTripsCommandsUseV2ForReadsAndV1ForWrites(t *testing.T) {
 		fieldsExclude string
 	}{
 		{name: "list", args: []string{"list"}, method: http.MethodGet, path: "/v2/trips/"},
-		{name: "show", args: []string{"show", "42"}, method: http.MethodGet, path: "/v2/trips/42/"},
+		{name: "show", args: []string{"show", "42"}, method: http.MethodGet, path: "/v1/trips/42", fieldsExclude: "documents,emails"},
 		{name: "create", args: []string{"create", "--name", "Copenhagen"}, method: http.MethodPost, path: "/v1/trips", fieldsExclude: "documents,emails"},
 		{name: "update", args: []string{"update", "42", "--name", "Copenhagen"}, method: http.MethodPatch, path: "/v1/trips/42", fieldsExclude: "documents,emails"},
 		{name: "delete", args: []string{"delete", "42"}, method: http.MethodDelete, path: "/v1/trips/42", fieldsExclude: "documents,emails"},
@@ -187,8 +187,11 @@ func TestTripsCommandsUseV2ForReadsAndV1ForWrites(t *testing.T) {
 
 func TestTripsShowEscapesIDPathSegment(t *testing.T) {
 	a, cleanup := testAPIApp(t, func(w http.ResponseWriter, r *http.Request) {
-		if got := r.RequestURI; !strings.HasPrefix(got, "/v2/trips/..%2Fme/") {
+		if got := r.RequestURI; !strings.HasPrefix(got, "/v1/trips/..%2Fme?") {
 			t.Errorf("request URI = %q, want escaped trip id segment", got)
+		}
+		if got := r.URL.Query().Get("fields!"); got != "documents,emails" {
+			t.Errorf("fields! = %q, want documents,emails", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"../me","name":"Escaped"}`))

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -712,8 +712,11 @@ func TestTypedToolEscapesPathIDs(t *testing.T) {
 	var called atomic.Int32
 	session, cleanup := connectTestSession(t, "test-token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called.Add(1)
-		if r.URL.EscapedPath() != "/v2/trips/a%2Fb/" {
-			t.Errorf("escaped path = %s, want /v2/trips/a%%2Fb/", r.URL.EscapedPath())
+		if r.URL.EscapedPath() != "/v1/trips/a%2Fb" {
+			t.Errorf("escaped path = %s, want /v1/trips/a%%2Fb", r.URL.EscapedPath())
+		}
+		if got := r.URL.Query().Get("fields!"); got != "documents,emails" {
+			t.Errorf("fields! = %q, want documents,emails", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"a/b"}`))

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -443,7 +443,7 @@ func (s *service) tripShow(ctx context.Context, req *mcp.CallToolRequest, in idI
 	if strings.TrimSpace(in.ID) == "" {
 		return nil, nil, fmt.Errorf("id is required")
 	}
-	return toolOutput(s.do(ctx, req, "GET", "/v2/trips/"+apiPathSegment(in.ID)+"/", nil, nil, "Trip "+in.ID))
+	return toolOutput(s.do(ctx, req, "GET", "/v1/trips/"+apiPathSegment(in.ID), tripDataQuery(nil), nil, "Trip "+in.ID))
 }
 
 func (s *service) tripCreate(ctx context.Context, req *mcp.CallToolRequest, in tripCreateInput) (*mcp.CallToolResult, any, error) {


### PR DESCRIPTION
## Summary

- restore individual trip reads to the supported `GET /v1/trips/{id}` endpoint while keeping trip lists on v2
- preserve the existing `fields!=documents,emails` filtering for CLI and MCP detail requests
- update the Go toolchain pin so the CI vulnerability scan uses patched standard-library packages
- document the repository's pull request conventions

## Implementation Details

- `internal/cli/cli.go`
  - updates `app.trips` so `tripsy trips show <id>` uses the supported v1 detail route and `tripDataQuery(nil)`
  - clarifies the command catalog: trip lists and itinerary subresource reads remain on v2, while individual trip details use v1
- `internal/mcpserver/tools.go`
  - updates `service.tripShow` to use the same supported v1 route and field exclusions
- `internal/cli/cli_test.go`
  - verifies v2 remains in use for trip lists and v1 is used for trip details
  - preserves coverage for escaped IDs and response field exclusions
- `internal/mcpserver/server_test.go`
  - updates typed-tool coverage for the v1 detail path, escaped IDs, and field exclusions
- `go.mod`
  - raises the Go version from 1.26.3 to 1.26.5, resolving the standard-library vulnerabilities reported by CI
- `AGENTS.md`
  - adds conventional PR title, labeling, readiness, and body-section requirements

No new files, types, or components were introduced.

## Validation

- `go test ./internal/cli ./internal/mcpserver`
- `make check`
  - gofumpt check
  - `go vet ./...`
  - `go test ./...`
  - install-script syntax check
- `make vulncheck`
  - zero called vulnerabilities with Go 1.26.5