### PR TITLE
fix: accept Tripsy API tokens on hosted MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ https://mcp.tripsy.app/ -> http://127.0.0.1:8787/
 https://mcp.tripsy.app/mcp -> http://127.0.0.1:8787/mcp
 ```
 
-HTTP MCP always requires each request to include `Authorization: Bearer <Tripsy token>`. The server validates that token against `/v1/me` and uses it only for that downstream Tripsy API request, so each remote client acts as its own Tripsy user.
+HTTP MCP always requires each request to include `Authorization: Bearer <token>`. When hosted OAuth is configured, the server first validates OAuth access tokens through the issuer's userinfo endpoint, then falls back to validating Tripsy API tokens against `/v1/me`. It uses the validated token only for that downstream Tripsy API request, so each remote client acts as its own Tripsy user.
 
 HTTP mode intentionally ignores `--token`, `TRIPSY_TOKEN`, keychain tokens, and legacy `credentials.json` tokens to avoid server-side credential fallback. For public hosted servers, keep `--disable-raw-request` enabled unless you intentionally want to expose the broader `tripsy_raw_request` tool.
 

--- a/cmd/tripsy-mcp/main.go
+++ b/cmd/tripsy-mcp/main.go
@@ -126,7 +126,7 @@ func runHTTP(server *mcp.Server, info mcpserver.RuntimeInfo, addr, path string, 
 		verifier := mcpserver.BearerTokenVerifier(info.APIBase)
 		authOptions := &auth.RequireBearerTokenOptions{}
 		if oauthConfig.enabled() {
-			verifier = mcpserver.OAuthBearerTokenVerifier(oauthConfig.userinfoURL())
+			verifier = mcpserver.HostedTokenVerifier(info.APIBase, oauthConfig.userinfoURL())
 			authOptions.ResourceMetadataURL = oauthConfig.resourceMetadataURL()
 		}
 		httpHandler = auth.RequireBearerToken(verifier, authOptions)(httpHandler)

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -295,7 +295,11 @@ func requireToken(client *api.Client) error {
 const tokenVerifierCacheTTL = 5 * time.Minute
 
 func BearerTokenVerifier(baseURL string) auth.TokenVerifier {
-	verifier := func(ctx context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
+	return cachedVerifier(bearerTokenVerifier(baseURL), tokenVerifierCacheTTL)
+}
+
+func bearerTokenVerifier(baseURL string) auth.TokenVerifier {
+	return func(ctx context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
 		token = strings.TrimSpace(token)
 		if token == "" {
 			return nil, fmt.Errorf("%w: empty Tripsy token", auth.ErrInvalidToken)
@@ -318,11 +322,14 @@ func BearerTokenVerifier(baseURL string) auth.TokenVerifier {
 			},
 		}, nil
 	}
-	return cachedVerifier(verifier, tokenVerifierCacheTTL)
 }
 
 func OAuthBearerTokenVerifier(userinfoEndpoint string) auth.TokenVerifier {
-	verifier := func(ctx context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
+	return cachedVerifier(oauthBearerTokenVerifier(userinfoEndpoint), tokenVerifierCacheTTL)
+}
+
+func oauthBearerTokenVerifier(userinfoEndpoint string) auth.TokenVerifier {
+	return func(ctx context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
 		token = strings.TrimSpace(token)
 		if token == "" {
 			return nil, fmt.Errorf("%w: empty OAuth access token", auth.ErrInvalidToken)
@@ -345,6 +352,20 @@ func OAuthBearerTokenVerifier(userinfoEndpoint string) auth.TokenVerifier {
 				tokenInfoAuthSchemeKey:  "Bearer",
 			},
 		}, nil
+	}
+}
+
+// HostedTokenVerifier accepts hosted OAuth access tokens and falls back to a
+// Tripsy API token only when the OAuth issuer rejects the credential.
+func HostedTokenVerifier(apiBaseURL, userinfoEndpoint string) auth.TokenVerifier {
+	oauthVerifier := oauthBearerTokenVerifier(userinfoEndpoint)
+	tripsyVerifier := bearerTokenVerifier(apiBaseURL)
+	verifier := func(ctx context.Context, token string, request *http.Request) (*auth.TokenInfo, error) {
+		info, err := oauthVerifier(ctx, token, request)
+		if err == nil || !errors.Is(err, auth.ErrInvalidToken) {
+			return info, err
+		}
+		return tripsyVerifier(ctx, token, request)
 	}
 	return cachedVerifier(verifier, tokenVerifierCacheTTL)
 }

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -835,6 +835,95 @@ func TestOAuthBearerTokenVerifierValidatesUserinfo(t *testing.T) {
 	}
 }
 
+func TestHostedTokenVerifierPrefersOAuthAccessToken(t *testing.T) {
+	var apiCalls atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls.Add(1)
+		http.Error(w, "unexpected Tripsy token validation", http.StatusInternalServerError)
+	}))
+	defer apiServer.Close()
+
+	userinfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer oauth-token" {
+			t.Errorf("Authorization = %q, want Bearer oauth-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"sub":"oauth-user"}`))
+	}))
+	defer userinfoServer.Close()
+
+	info, err := HostedTokenVerifier(apiServer.URL, userinfoServer.URL)(testContext(t), "oauth-token", httptest.NewRequest(http.MethodPost, "/mcp", nil))
+	if err != nil {
+		t.Fatalf("HostedTokenVerifier() failed: %v", err)
+	}
+	if got := info.Extra[tokenInfoAuthSchemeKey]; got != "Bearer" {
+		t.Fatalf("auth scheme = %v, want Bearer", got)
+	}
+	if got := apiCalls.Load(); got != 0 {
+		t.Fatalf("Tripsy API called %d times, want 0", got)
+	}
+}
+
+func TestHostedTokenVerifierFallsBackToTripsyToken(t *testing.T) {
+	var userinfoCalls atomic.Int32
+	userinfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		userinfoCalls.Add(1)
+		http.Error(w, "invalid OAuth token", http.StatusUnauthorized)
+	}))
+	defer userinfoServer.Close()
+
+	var apiCalls atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls.Add(1)
+		if got := r.Header.Get("Authorization"); got != "Token tripsy-token" {
+			t.Errorf("Authorization = %q, want Token tripsy-token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":42}`))
+	}))
+	defer apiServer.Close()
+
+	verifier := HostedTokenVerifier(apiServer.URL, userinfoServer.URL)
+	for range 2 {
+		info, err := verifier(testContext(t), "tripsy-token", httptest.NewRequest(http.MethodPost, "/mcp", nil))
+		if err != nil {
+			t.Fatalf("HostedTokenVerifier() failed: %v", err)
+		}
+		if got := info.Extra[tokenInfoAuthSchemeKey]; got != "Token" {
+			t.Fatalf("auth scheme = %v, want Token", got)
+		}
+	}
+	if got := userinfoCalls.Load(); got != 1 {
+		t.Fatalf("userinfo called %d times, want 1", got)
+	}
+	if got := apiCalls.Load(); got != 1 {
+		t.Fatalf("Tripsy API called %d times, want 1", got)
+	}
+}
+
+func TestHostedTokenVerifierDoesNotFallbackAfterOAuthServerError(t *testing.T) {
+	userinfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+	}))
+	defer userinfoServer.Close()
+
+	var apiCalls atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		apiCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":42}`))
+	}))
+	defer apiServer.Close()
+
+	_, err := HostedTokenVerifier(apiServer.URL, userinfoServer.URL)(testContext(t), "token", httptest.NewRequest(http.MethodPost, "/mcp", nil))
+	if err == nil {
+		t.Fatal("HostedTokenVerifier() succeeded, want userinfo error")
+	}
+	if got := apiCalls.Load(); got != 0 {
+		t.Fatalf("Tripsy API called %d times, want 0", got)
+	}
+}
+
 func TestBearerTokenVerifierCachesRepeatedTokens(t *testing.T) {
 	var calls atomic.Int32
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary

- Restore manual Tripsy API token authentication on the hosted MCP server.
- Continue preferring OAuth access tokens and preserve the correct downstream authentication scheme.
- Avoid falling back when the OAuth userinfo service fails for reasons other than an invalid token.

## Implementation Details

- `cmd/tripsy-mcp/main.go`: select the new `HostedTokenVerifier` whenever hosted OAuth discovery is enabled.
- `internal/mcpserver/server.go`: split the existing OAuth and Tripsy verification logic into reusable uncached verifiers, compose them in `HostedTokenVerifier`, and cache the final successful classification.
- `internal/mcpserver/server_test.go`: verify OAuth preference, Tripsy token fallback, correct `Bearer`/`Token` scheme selection, cache behavior, and no fallback after OAuth server errors.
- `README.md`: document the hosted OAuth-first, Tripsy-token-fallback behavior.

## Validation

- `make check`
  - formatting check
  - `go vet ./...`
  - `go test ./...`
  - install script syntax check
- `git diff --check`