### PR TITLE
chore: update Go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tripsyapp/cli
 
-go 1.26.5
+go 1.26.6
 
 require github.com/modelcontextprotocol/go-sdk v1.5.0
 


### PR DESCRIPTION
## Summary

- Upgrade the Go toolchain from 1.26.5 to 1.26.6.
- Pick up the standard-library security fixes required for the vulnerability check that failed on #9.

## Implementation Details

- Updated the `go` directive in `go.mod` to 1.26.6.
- CI and release workflows consume this version through `go-version-file: go.mod`, so no workflow-specific pins were needed.
- The Docker build already uses the floating `golang:1.26-alpine` patch tag and requires no change.

## Validation

- `make check`
- `make vulncheck` — no called vulnerabilities found

Related: #9