### PR TITLE
feat: redirect MCP browser visits to setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Use Tripsy's MCP server when an agent or app supports MCP. Prefer MCP for model-
 
 Tripsy operates a public MCP server at `https://mcp.tripsy.app`. OAuth-capable clients such as Claude and ChatGPT can connect directly without installing anything. Authentication uses the Tripsy OAuth authorization flow at `https://my.tripsy.app`.
 
+Opening the hosted endpoint in a web browser redirects to the [Tripsy AI Tools setup guide](https://tripsy.help/article/97-ai-tools). Machine requests continue to receive the MCP OAuth challenge.
+
 The previous `https://mcp.tripsy.app/mcp` endpoint remains available for existing clients.
 
 ### Self-Hosted Stdio

--- a/cmd/tripsy-mcp/main.go
+++ b/cmd/tripsy-mcp/main.go
@@ -8,9 +8,11 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,7 +23,10 @@ import (
 	"github.com/tripsyapp/cli/internal/mcpserver"
 )
 
-const openAIAppsChallengeResponse = "aYBlXTk9xrrpyW7v1pieVqn9w9BxXjRLWPak0uJtkqc"
+const (
+	openAIAppsChallengeResponse = "aYBlXTk9xrrpyW7v1pieVqn9w9BxXjRLWPak0uJtkqc"
+	mcpDocumentationURL         = "https://tripsy.help/article/97-ai-tools"
+)
 
 func main() {
 	var opts mcpserver.Options
@@ -149,7 +154,7 @@ func runHTTP(server *mcp.Server, info mcpserver.RuntimeInfo, addr, path string, 
 	}
 	paths := registerMCPHTTPHandlers(mux, path, httpHandler)
 	log.Printf("Tripsy MCP listening on http://%s%s (aliases=%s api_base=%s auth_backend=%s has_token=%t require_bearer=%t)", addr, path, strings.Join(paths, ","), info.APIBase, info.AuthBackend, info.HasToken, requireBearer)
-	log.Fatal(newHTTPServer(addr, mux).ListenAndServe())
+	log.Fatal(newHTTPServer(addr, redirectBrowserToMCPDocumentation(mux)).ListenAndServe())
 }
 
 func newHTTPServer(addr string, handler http.Handler) *http.Server {
@@ -159,6 +164,37 @@ func newHTTPServer(addr string, handler http.Handler) *http.Server {
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       2 * time.Minute,
 	}
+}
+
+func redirectBrowserToMCPDocumentation(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/" || r.Header.Get("Authorization") != "" || !acceptsHTML(r.Header.Get("Accept")) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Add("Vary", "Accept")
+		w.Header().Add("Vary", "Authorization")
+		http.Redirect(w, r, mcpDocumentationURL, http.StatusFound)
+	})
+}
+
+func acceptsHTML(accept string) bool {
+	for _, value := range strings.Split(accept, ",") {
+		mediaType, params, err := mime.ParseMediaType(strings.TrimSpace(value))
+		if err != nil || (mediaType != "text/html" && mediaType != "application/xhtml+xml") {
+			continue
+		}
+		if quality, ok := params["q"]; ok {
+			parsedQuality, err := strconv.ParseFloat(quality, 64)
+			if err != nil || parsedQuality <= 0 {
+				continue
+			}
+		}
+		return true
+	}
+	return false
 }
 
 type explicitToolAnnotationsWriter struct {

--- a/cmd/tripsy-mcp/main_test.go
+++ b/cmd/tripsy-mcp/main_test.go
@@ -71,6 +71,77 @@ func TestNewHTTPServerHasDefensiveTimeouts(t *testing.T) {
 	}
 }
 
+func TestRedirectBrowserToMCPDocumentation(t *testing.T) {
+	nextCalls := 0
+	handler := redirectBrowserToMCPDocumentation(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		nextCalls++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml;q=0.9,*/*;q=0.8")
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	if res.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d", res.Code, http.StatusFound)
+	}
+	if got := res.Header().Get("Location"); got != mcpDocumentationURL {
+		t.Fatalf("Location = %q, want %q", got, mcpDocumentationURL)
+	}
+	if got := res.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+	vary := strings.Join(res.Header().Values("Vary"), ",")
+	if !strings.Contains(vary, "Accept") || !strings.Contains(vary, "Authorization") {
+		t.Fatalf("Vary = %q, want Accept and Authorization", vary)
+	}
+	if nextCalls != 0 {
+		t.Fatalf("next handler called %d times, want 0", nextCalls)
+	}
+}
+
+func TestRedirectBrowserToMCPDocumentationPreservesMachineRequests(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		path          string
+		accept        string
+		authorization string
+	}{
+		{name: "MCP POST", method: http.MethodPost, path: "/", accept: "application/json, text/event-stream"},
+		{name: "MCP SSE GET", method: http.MethodGet, path: "/", accept: "text/event-stream"},
+		{name: "legacy MCP path", method: http.MethodGet, path: "/mcp", accept: "text/html"},
+		{name: "authenticated browser GET", method: http.MethodGet, path: "/", accept: "text/html", authorization: "Bearer token"},
+		{name: "generic client", method: http.MethodGet, path: "/", accept: "*/*"},
+		{name: "HTML explicitly rejected", method: http.MethodGet, path: "/", accept: "text/html;q=0, text/event-stream"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := redirectBrowserToMCPDocumentation(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="https://mcp.test/.well-known/oauth-protected-resource"`)
+				w.WriteHeader(http.StatusUnauthorized)
+			}))
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("Accept", tt.accept)
+			if tt.authorization != "" {
+				req.Header.Set("Authorization", tt.authorization)
+			}
+			res := httptest.NewRecorder()
+
+			handler.ServeHTTP(res, req)
+
+			if res.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", res.Code, http.StatusUnauthorized)
+			}
+			if got := res.Header().Get("WWW-Authenticate"); got == "" {
+				t.Fatal("WWW-Authenticate challenge was not preserved")
+			}
+		})
+	}
+}
+
 func TestOpenAIAppsChallenge(t *testing.T) {
 	res := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/.well-known/openai-apps-challenge", nil)


### PR DESCRIPTION
## Summary

- Redirect unauthenticated browser visits to `https://mcp.tripsy.app/` to the Tripsy AI Tools setup guide.
- Preserve the MCP OAuth challenge for machine requests, legacy `/mcp` traffic, and requests that supply an Authorization header.
- Prevent intermediaries from caching the content-negotiated redirect.

## Implementation Details

- `cmd/tripsy-mcp/main.go`: add `redirectBrowserToMCPDocumentation`, which returns a temporary redirect to `https://tripsy.help/article/97-ai-tools` only for unauthenticated `GET /` requests that accept HTML. Add `acceptsHTML` to parse media types and honor zero-quality HTML entries. Wrap the HTTP mux outside bearer authentication so human browser navigation can reach the guide while all non-browser traffic continues through the existing handler. Mark redirects `Cache-Control: no-store` and vary them on `Accept` and `Authorization`.
- `cmd/tripsy-mcp/main_test.go`: cover the browser redirect and verify that MCP POST, SSE GET, `/mcp`, authenticated browser, generic client, and HTML-rejected requests retain the underlying OAuth response.
- `README.md`: document the browser redirect alongside the hosted endpoint instructions.

## Validation

- `go test ./cmd/tripsy-mcp`
- `make check`
- `make vulncheck`
- `git diff --check`