### PR TITLE
chore: publish Tripsy to the official MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,56 @@
+name: Publish MCP Registry
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Optional registry version override; defaults to server.json
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set registry version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          version="$INPUT_VERSION"
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          fi
+
+          if [[ -n "$version" ]]; then
+            jq --arg version "$version" '.version = $version' server.json > server.tmp
+            mv server.tmp server.json
+          fi
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Validate registry manifest
+        run: ./mcp-publisher validate
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.tripsyapp/tripsy",
+  "title": "Tripsy",
+  "description": "Plan trips and manage itineraries, stays, transport, activities, expenses, and documents in Tripsy.",
+  "version": "1.7.1",
+  "websiteUrl": "https://tripsy.help/article/97-ai-tools",
+  "repository": {
+    "url": "https://github.com/tripsyapp/cli",
+    "source": "github",
+    "id": "1220375872"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.tripsy.app"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add the first-party Tripsy manifest for the official MCP Registry.
- Automate registry publication for release tags and manual first-time publication.

## Implementation Details

- `server.json`: defines `io.github.tripsyapp/tripsy` as the official Tripsy MCP server, links the public source repository and AI setup guide, and advertises the hosted Streamable HTTP endpoint at `https://mcp.tripsy.app`.
- `.github/workflows/publish-mcp-registry.yml`: validates and publishes the manifest with the official `mcp-publisher`, using short-lived GitHub Actions OIDC credentials. Release tags synchronize the registry version with the tag; manual runs can use the manifest version or an explicit override.

## Validation

- `mcp-publisher validate` (official publisher v1.8.1)
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish-mcp-registry.yml`
- `make check`
- `make vulncheck`
- Verified the hosted endpoint returns the standard MCP OAuth protected-resource challenge and valid discovery metadata.